### PR TITLE
Fixes a bug where non braille characters are incorrectly represented when converting the int map to a string

### DIFF
--- a/drawille.go
+++ b/drawille.go
@@ -4,224 +4,225 @@ package drawille
 import "math"
 
 var pixel_map = [4][2]int{
-  {0x1, 0x8},
-  {0x2, 0x10},
-  {0x4, 0x20},
-  {0x40, 0x80}}
+	{0x1, 0x8},
+	{0x2, 0x10},
+	{0x4, 0x20},
+	{0x40, 0x80}}
 
 // Braille chars start at 0x2800
 var braille_char_offset = 0x2800
 
-func getPixel(y,x int) int {
-  var cy,cx int
-  if y >= 0 {
-    cy = y%4
-  } else {
-    cy = 3 + ((y+1)%4)
-  }
-  if x >= 0 {
-    cx = x%2
-  } else {
-    cx = 1 + ((x+1)%2)
-  }
-  return pixel_map[cy][cx]
+func getPixel(y, x int) int {
+	var cy, cx int
+	if y >= 0 {
+		cy = y % 4
+	} else {
+		cy = 3 + ((y + 1) % 4)
+	}
+	if x >= 0 {
+		cx = x % 2
+	} else {
+		cx = 1 + ((x + 1) % 2)
+	}
+	return pixel_map[cy][cx]
 }
 
-type Canvas struct{
-  LineEnding string
-  chars map[int]map[int]int
+type Canvas struct {
+	LineEnding string
+	chars      map[int]map[int]int
 }
 
 // Make a new canvas
 func NewCanvas() Canvas {
-  c := Canvas{LineEnding:"\n"}
-  c.Clear()
-  return c
+	c := Canvas{LineEnding: "\n"}
+	c.Clear()
+	return c
 }
 
 func (c Canvas) MaxY() int {
-  max := 0
-  for k,_ := range c.chars {
-    if k>max {
-      max = k
-    }
-  }
-  return max*4
+	max := 0
+	for k, _ := range c.chars {
+		if k > max {
+			max = k
+		}
+	}
+	return max * 4
 }
 
 func (c Canvas) MinY() int {
-  min := 0
-  for k,_ := range c.chars {
-    if k<min {
-      min = k
-    }
-  }
-  return min*4
+	min := 0
+	for k, _ := range c.chars {
+		if k < min {
+			min = k
+		}
+	}
+	return min * 4
 }
 
 func (c Canvas) MaxX() int {
-  max := 0
-  for _,v := range c.chars {
-    for k,_ := range v {
-      if k>max {
-        max = k
-      }
-    }
-  }
-  return max*2
+	max := 0
+	for _, v := range c.chars {
+		for k, _ := range v {
+			if k > max {
+				max = k
+			}
+		}
+	}
+	return max * 2
 }
 
 func (c Canvas) MinX() int {
-  min := 0
-  for _,v := range c.chars {
-    for k,_ := range v {
-      if k<min {
-        min = k
-      }
-    }
-  }
-  return min*2
+	min := 0
+	for _, v := range c.chars {
+		for k, _ := range v {
+			if k < min {
+				min = k
+			}
+		}
+	}
+	return min * 2
 }
 
 // Clear all pixels
 func (c *Canvas) Clear() {
-  c.chars = make(map[int]map[int]int)
+	c.chars = make(map[int]map[int]int)
 }
 
 // Convert x,y to cols, rows
-func (c Canvas) get_pos(x,y int) (int,int) {
-  return (x/2),(y/4)
+func (c Canvas) get_pos(x, y int) (int, int) {
+	return (x / 2), (y / 4)
 }
 
 // Set a pixel of c
-func (c *Canvas) Set(x,y int) {
-  px,py := c.get_pos(x,y)
-  if m := c.chars[py];m == nil {
-    c.chars[py] = make(map[int]int)
-  }
-  val := c.chars[py][px]
-  mapv := getPixel(y,x)
-  c.chars[py][px] = val|mapv
+func (c *Canvas) Set(x, y int) {
+	px, py := c.get_pos(x, y)
+	if m := c.chars[py]; m == nil {
+		c.chars[py] = make(map[int]int)
+	}
+	val := c.chars[py][px]
+	mapv := getPixel(y, x)
+	c.chars[py][px] = val | mapv
 }
 
 // Unset a pixel of c
-func (c *Canvas) UnSet(x,y int) {
-  px,py := c.get_pos(x,y)
-  x,y = int(math.Abs(float64(x))),int(math.Abs(float64(y)))
-  if m := c.chars[py]; m == nil {
-    c.chars[py] = make(map[int]int)
-  }
-  c.chars[py][px] = c.chars[py][px]&^getPixel(y,x)
+func (c *Canvas) UnSet(x, y int) {
+	px, py := c.get_pos(x, y)
+	x, y = int(math.Abs(float64(x))), int(math.Abs(float64(y)))
+	if m := c.chars[py]; m == nil {
+		c.chars[py] = make(map[int]int)
+	}
+	c.chars[py][px] = c.chars[py][px] &^ getPixel(y, x)
 }
+
 // Toggle a point
-func (c *Canvas) Toggle(x,y int) {
-  px,py := c.get_pos(x,y)
-  if (c.chars[py][px] & getPixel(y,x)) != 0 {
-    c.UnSet(x,y)
-  } else {
-    c.Set(x,y)
-  }
+func (c *Canvas) Toggle(x, y int) {
+	px, py := c.get_pos(x, y)
+	if (c.chars[py][px] & getPixel(y, x)) != 0 {
+		c.UnSet(x, y)
+	} else {
+		c.Set(x, y)
+	}
 }
 
 // Set text to the given coordinates
-func (c *Canvas) SetText(x,y int, text string) {
-  x,y = x/2,y/4
-  if m := c.chars[y]; m == nil {
-    c.chars[y] = make(map[int]int)
-  }
-  for i,char := range text {
-    c.chars[y][x+i] = int(char)
-  }
+func (c *Canvas) SetText(x, y int, text string) {
+	x, y = x/2, y/4
+	if m := c.chars[y]; m == nil {
+		c.chars[y] = make(map[int]int)
+	}
+	for i, char := range text {
+		c.chars[y][x+i] = int(char) - braille_char_offset
+	}
 }
 
 // Get pixel at the given coordinates
-func (c Canvas) Get(x,y int) bool {
-  dot_index := pixel_map[y%4][x%2]
-  x,y = x/2,y/4
-  char := c.chars[y][x]
-  return (char & dot_index) != 0
+func (c Canvas) Get(x, y int) bool {
+	dot_index := pixel_map[y%4][x%2]
+	x, y = x/2, y/4
+	char := c.chars[y][x]
+	return (char & dot_index) != 0
 }
 
 // Retrieve the rows from a given view
-func (c Canvas) Rows(minX,minY,maxX,maxY int) []string {
-  minrow,maxrow := minY/4,(maxY)/4
-  mincol,maxcol := minX/2,(maxX)/2
-  
-  ret := make([]string,0)
-  for rownum := minrow;rownum < (maxrow+1);rownum=rownum+1 {
-    row := ""
-    for x := mincol;x<(maxcol+1);x=x+1 {
-      char := c.chars[rownum][x]
-      row += string(rune(char+braille_char_offset))
-    }
-    ret = append(ret,row)
-  }
-  return ret
+func (c Canvas) Rows(minX, minY, maxX, maxY int) []string {
+	minrow, maxrow := minY/4, (maxY)/4
+	mincol, maxcol := minX/2, (maxX)/2
+
+	ret := make([]string, 0)
+	for rownum := minrow; rownum < (maxrow + 1); rownum = rownum + 1 {
+		row := ""
+		for x := mincol; x < (maxcol + 1); x = x + 1 {
+			char := c.chars[rownum][x]
+			row += string(rune(char + braille_char_offset))
+		}
+		ret = append(ret, row)
+	}
+	return ret
 }
 
 // Retrieve a string representation of the frame at the given parameters
-func (c Canvas) Frame(minX,minY,maxX,maxY int) string {
-  var ret string
-  for _,row := range c.Rows(minX,minY,maxX,maxY) {
-    ret += row
-    ret += c.LineEnding
-  }
-  return ret
+func (c Canvas) Frame(minX, minY, maxX, maxY int) string {
+	var ret string
+	for _, row := range c.Rows(minX, minY, maxX, maxY) {
+		ret += row
+		ret += c.LineEnding
+	}
+	return ret
 }
 
 func (c Canvas) String() string {
-  return c.Frame(c.MinX(),c.MinY(),c.MaxX(),c.MaxY())
+	return c.Frame(c.MinX(), c.MinY(), c.MaxX(), c.MaxY())
 }
 
-func (c *Canvas) DrawLine(x1,y1, x2,y2 float64) {
-  xdiff := math.Abs(x1-x2)
-  ydiff := math.Abs(y2-y1)
-  
-  var xdir,ydir float64
-  if x1 <= x2 {
-    xdir = 1
-  } else {
-    xdir = -1
-  }
-  if y1 <= y2 {
-    ydir = 1
-  } else {
-    ydir = -1
-  }
-  
-  r := math.Max(xdiff, ydiff)
-  
-  for i:=0;i<round(r)+1;i=i+1 {
-    x,y := x1,y1
-    if ydiff != 0 {
-      y += (float64(i)*ydiff)/(r*ydir)
-    }
-    if xdiff != 0 {
-      x += (float64(i)*xdiff)/(r*xdir)
-    }
-    c.Toggle(round(x),round(y))
-  }
+func (c *Canvas) DrawLine(x1, y1, x2, y2 float64) {
+	xdiff := math.Abs(x1 - x2)
+	ydiff := math.Abs(y2 - y1)
+
+	var xdir, ydir float64
+	if x1 <= x2 {
+		xdir = 1
+	} else {
+		xdir = -1
+	}
+	if y1 <= y2 {
+		ydir = 1
+	} else {
+		ydir = -1
+	}
+
+	r := math.Max(xdiff, ydiff)
+
+	for i := 0; i < round(r)+1; i = i + 1 {
+		x, y := x1, y1
+		if ydiff != 0 {
+			y += (float64(i) * ydiff) / (r * ydir)
+		}
+		if xdiff != 0 {
+			x += (float64(i) * xdiff) / (r * xdir)
+		}
+		c.Toggle(round(x), round(y))
+	}
 }
 
-func (c *Canvas) DrawPolygon(center_x,center_y,sides,radius float64) {
-  degree := 360/sides
-  for n:=0;n<int(sides);n=n+1 {
-    a := float64(n)*degree
-    b := float64(n+1)*degree
-    
-    x1 := (center_x+(math.Cos(radians(a))*(radius/2+1)))
-    y1 := (center_y+(math.Sin(radians(a))*(radius/2+1)))
-    x2 := (center_x+(math.Cos(radians(b))*(radius/2+1)))
-    y2 := (center_y+(math.Sin(radians(b))*(radius/2+1)))
-    
-    c.DrawLine(x1,y1,x2,y2)
-  }
+func (c *Canvas) DrawPolygon(center_x, center_y, sides, radius float64) {
+	degree := 360 / sides
+	for n := 0; n < int(sides); n = n + 1 {
+		a := float64(n) * degree
+		b := float64(n+1) * degree
+
+		x1 := (center_x + (math.Cos(radians(a)) * (radius/2 + 1)))
+		y1 := (center_y + (math.Sin(radians(a)) * (radius/2 + 1)))
+		x2 := (center_x + (math.Cos(radians(b)) * (radius/2 + 1)))
+		y2 := (center_y + (math.Sin(radians(b)) * (radius/2 + 1)))
+
+		c.DrawLine(x1, y1, x2, y2)
+	}
 }
 
 func radians(d float64) float64 {
-  return d*(math.Pi/180)
+	return d * (math.Pi / 180)
 }
 
 func round(x float64) int {
-  return int(x+0.5)
+	return int(x + 0.5)
 }


### PR DESCRIPTION
By subtracting the braille offset from the value of the characters in SetText(), this zeros out the later addition of the braille offset so that the characters are not transformed into new characters in Rows()